### PR TITLE
Add computations functionality

### DIFF
--- a/src/include/concore/computation/_cpo_run_with.hpp
+++ b/src/include/concore/computation/_cpo_run_with.hpp
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <concore/detail/cxx_features.hpp>
+#include <concore/detail/extra_type_traits.hpp>
+#include <concore/detail/concept_macros.hpp>
+
+#if CONCORE_CXX_HAS_CONCEPTS
+#include <concepts>
+#endif
+#include <type_traits>
+
+namespace concore {
+
+namespace computation {
+
+namespace detail {
+namespace cpo_run_with {
+
+CONCORE_DEF_REQUIRES(meets_tag_invoke,                                               //
+        CONCORE_LIST(typename Tag, typename C, typename R), CONCORE_LIST(Tag, C, R), //
+        (requires(C&& c, R&& r) { tag_invoke(Tag{}, (C &&) c, (R &&) r); }),         // concepts
+        tag_invoke(Tag{}, CONCORE_DECLVAL(C), CONCORE_DECLVAL(R))                    // pre-concepts
+);
+CONCORE_DEF_REQUIRES(meets_inner_fun,                             //
+        CONCORE_LIST(typename C, typename R), CONCORE_LIST(C, R), //
+        (requires(C&& c, R&& r) { c.run_with((R &&) r); }),       // concepts
+        CONCORE_DECLVAL(C).run_with(CONCORE_DECLVAL(R))           // pre-concepts
+);
+CONCORE_DEF_REQUIRES(meets_outer_fun,                               //
+        CONCORE_LIST(typename C, typename R), CONCORE_LIST(C, R),   //
+        (requires(C&& c, R&& r) { run_with((C &&) c, (R &&) r); }), // concepts
+        run_with(CONCORE_DECLVAL(C), CONCORE_DECLVAL(R))            // pre-concepts
+);
+
+template <typename Tag, typename C, typename R>
+CONCORE_CONCEPT_OR_BOOL(has_tag_invoke) = meets_tag_invoke<Tag, C, R>;
+
+template <typename Tag, typename C, typename R>
+CONCORE_CONCEPT_OR_BOOL(has_inner_fun) = !has_tag_invoke<Tag, C, R> && meets_inner_fun<C, R>;
+
+template <typename Tag, typename C, typename R>
+CONCORE_CONCEPT_OR_BOOL(has_outer_fun) = !has_tag_invoke<Tag, C, R> &&
+                                         !has_inner_fun<Tag, C, R> && meets_outer_fun<C, R>;
+
+inline const struct run_with_t final {
+    CONCORE_TEMPLATE_COND(CONCORE_LIST(typename C, typename R), (has_tag_invoke<run_with_t, C, R>))
+    void operator()(C&& c, R&& r) const                                 //
+            noexcept(noexcept(tag_invoke(*this, (C &&) c, (R &&) r))) { //
+        tag_invoke(run_with_t{}, (C &&) c, (R &&) r);
+    }
+    CONCORE_TEMPLATE_COND(CONCORE_LIST(typename C, typename R), (has_inner_fun<run_with_t, C, R>))
+    void operator()(C&& c, R&& r) const                         //
+            noexcept(noexcept(((C &&) c).run_with((R &&) r))) { //
+        ((C &&) c).run_with((R &&) r);
+    }
+    CONCORE_TEMPLATE_COND(CONCORE_LIST(typename C, typename R), (has_outer_fun<run_with_t, C, R>))
+    void operator()(C&& c, R&& r) const                        //
+            noexcept(noexcept(run_with((C &&) c, (R &&) r))) { //
+        run_with((C &&) c, (R &&) r);
+    }
+} run_with{};
+
+template <typename C, typename R>
+CONCORE_CONCEPT_OR_BOOL(has_run_with) =
+        meets_tag_invoke<run_with_t, C, R> || meets_inner_fun<C, R> || meets_outer_fun<C, R>;
+
+} // namespace cpo_run_with
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief CPO for void run_with(computation, receiver).
+ *
+ * @param computation   the computation that need to be run
+ * @param receiver      the receiver that will get the completion signal from the computation
+ *
+ * @details
+ *
+ * This CPO essentially introduces a functor object with the following signature:
+ * @code{.cpp}
+ *      template <typename C, typename Recv>
+ *      void run_with(C computation, Recv receiver);
+ * @endcode
+ *
+ * By using this CPO, we allow the user to define the `run_with` functions for a computation C in
+ * three ways:
+ * 1) by creating a tag_invoke specialization
+ * 2) by adding `run_with` as a method inside C
+ * 3) by adding `run_with(C, R)` as a free function near C
+ *
+ * Example for creating a tag_invoke specialization:
+ * @code{.cpp}
+ *      template <typename C, typename Recv>
+ *      void run_with(run_with_t, C computation, Recv receiver);
+ * @endcode
+ *
+ * Example for using a method inside class C
+ * @code{.cpp}
+ *      struct C {
+ *          ...
+ *          template <typename Recv>
+ *          void run_with(Recv receiver);
+ *      };
+ * @endcode
+ *
+ * Example for using a free function outside C
+ * @code{.cpp}
+ *      struct C;
+ *
+ *      template <typename Recv>
+ *      void run_with(C computation, Recv receiver);
+ * @endcode
+ *
+ * This is needed for the @ref computation concept. It is also used in the library to start
+ * computations. The end-user typically doesn't have to call this.
+ *
+ * @see computation
+ */
+using detail::cpo_run_with::run_with;
+
+/**
+ * @brief Tag type to be used to specialize `tag_invoke` for the run_with CPO.
+ *
+ * @see run_with
+ */
+using detail::cpo_run_with::run_with_t;
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/bind.hpp
+++ b/src/include/concore/computation/bind.hpp
@@ -175,7 +175,7 @@ inline namespace v1 {
  * @see     transform(), bind_error()
  */
 template <typename PrevComp, typename F>
-detail::bind_computation<PrevComp, F> bind(PrevComp prevComp, F chainFun) {
+inline detail::bind_computation<PrevComp, F> bind(PrevComp prevComp, F chainFun) {
     return {(PrevComp &&) prevComp, (F &&) chainFun};
 }
 
@@ -218,7 +218,7 @@ detail::bind_computation<PrevComp, F> bind(PrevComp prevComp, F chainFun) {
  * @see     bind(), transform()
  */
 template <typename PrevComp, typename F>
-detail::bind_error_computation<PrevComp, F> bind_error(PrevComp prevComp, F chainFun) {
+inline detail::bind_error_computation<PrevComp, F> bind_error(PrevComp prevComp, F chainFun) {
     return {(PrevComp &&) prevComp, (F &&) chainFun};
 }
 

--- a/src/include/concore/computation/bind.hpp
+++ b/src/include/concore/computation/bind.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#include <concore/_cpo/_cpo_set_value.hpp>
+#include <concore/_cpo/_cpo_set_error.hpp>
+#include <concore/_cpo/_cpo_set_done.hpp>
+#include <concore/computation/computation.hpp>
+
+#include <exception>
+#include <functional>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename ParamT, typename F>
+struct bind_result {
+    using type = typename std::invoke_result_t<F, ParamT>::value_type;
+};
+
+template <typename F>
+struct bind_result<void, F> {
+    using type = typename std::invoke_result_t<F>::value_type;
+};
+
+template <typename F, typename R>
+struct bind_computation_receiver {
+    R finalRecv_;
+    F chainFun_;
+
+    template <typename... Val>
+    void set_value(Val... val) { // zero or one parameter
+        try {
+            // Invoke the function and get the next computation
+            auto nextComputation = std::invoke((F&)chainFun_, (Val &&) val...);
+            static_assert(concore::computation::computation<decltype(nextComputation)>,
+                    "returned object is not a computation");
+            // Run the second computation with the final receiver
+            concore::computation::run_with(std::move(nextComputation), (R &&) finalRecv_);
+        } catch (...) {
+            // If the functor throws, report this as an error
+            concore::set_error((R &&) finalRecv_, std::current_exception());
+        }
+    }
+    void set_done() noexcept { concore::set_done((R &&) finalRecv_); }
+    void set_error(std::exception_ptr e) noexcept { concore::set_error((R &&) finalRecv_, e); }
+};
+
+template <typename F, typename R, typename PrevCompValT>
+struct bind_error_computation_receiver {
+    R finalRecv_;
+    F chainFun_;
+
+    template <typename... Val>
+    void set_value(Val... val) { // zero or one parameter
+        try {
+            // Just forward the value
+            concore::set_value((R &&) finalRecv_, (Val &&) val...);
+        } catch (...) {
+            concore::set_error((R &&) finalRecv_, std::current_exception());
+        }
+    }
+    void set_done() noexcept { concore::set_done((R &&) finalRecv_); }
+    void set_error(std::exception_ptr e) noexcept {
+        try {
+            // Invoke the function and get the next computation
+            auto nextComputation = std::invoke((F&)chainFun_, e);
+            using next_type = decltype(nextComputation);
+            static_assert(concore::computation::computation<next_type>,
+                    "returned object is not a computation");
+            static_assert(std::is_same_v<PrevCompValT, typename next_type::value_type>,
+                    "Computation types do not match");
+            // Run the second computation with the final receiver
+            concore::computation::run_with(std::move(nextComputation), (R &&) finalRecv_);
+
+        } catch (...) {
+            concore::set_error((R &&) finalRecv_, std::current_exception());
+        }
+    }
+};
+
+template <typename PrevComp, typename F>
+struct bind_computation {
+    using value_type = typename bind_result<typename PrevComp::value_type, F>::type;
+
+    bind_computation(PrevComp prevComp, F chainFun)
+        : prevComp_((PrevComp &&) prevComp)
+        , chainFun_((F &&) chainFun) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        using recv_type = bind_computation_receiver<F, Recv>;
+        auto recv = recv_type{(Recv &&) r, (F &&) chainFun_};
+        concore::computation::run_with((PrevComp &&) prevComp_, std::move(recv));
+    }
+
+private:
+    PrevComp prevComp_;
+    F chainFun_;
+};
+
+template <typename PrevComp, typename F>
+struct bind_error_computation {
+    using value_type = typename std::invoke_result_t<F, std::exception_ptr>::value_type;
+
+    bind_error_computation(PrevComp prevComp, F chainFun)
+        : prevComp_((PrevComp &&) prevComp)
+        , chainFun_((F &&) chainFun) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        using recv_type = bind_error_computation_receiver<F, Recv, typename PrevComp::value_type>;
+        auto recv = recv_type{(Recv &&) r, (F &&) chainFun_};
+        concore::computation::run_with((PrevComp &&) prevComp_, std::move(recv));
+    }
+
+private:
+    PrevComp prevComp_;
+    F chainFun_;
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Applies "bind" monadic operation to chain two computations
+ * @tparam  PrevComp    The type of the previous computation
+ * @tparam  F           The type of functor used to generate the second computation
+ * @param   prevComp    The previous computation we used to chain to
+ * @param   chainFun    The functor used to generate the second computation (from the prev result)
+ * @return  A computation object
+ * @details
+ *
+ * This chains two computations. The first computation is given directly as the first argument. The
+ * second computation is generated by calling the functor passed as the second argument. This
+ * functor is called with the result of the previous computation, so that proper chaining is made.
+ * The functor must return a computation object.
+ *
+ * The chaining works even if the first computation yields void; in this case the given function
+ * should not have any parameter, and the computations are just executed one after the other.
+ *
+ * Starting this computation will start the previous computation then the computation returned by
+ * the functor that will finally be using the receiver passed when starting the computation.
+ *
+ * The chain function will be called on the thread used by the previous computation to yield its
+ * result.
+ *
+ * If the previous computation is cancelled, or has an error, then the transform functor will not be
+ * called, and the done/error state will be just forwarded.
+ *
+ * The bind operation can be used to build more complex transformations on computations.
+ * Example of how one can build a simple 'transform' computation algorithm with 'bind':
+ * @code{.cpp}
+ *      template <typename PrevComp, typename F>
+ *      auto transform(PrevComp c, F f) {
+ *          using interim_type = typename PrevComp::value_type;
+ *          auto chainFun = [f] (interim_type val) {
+ *              return just_value(f(val));
+ *          };
+ *          return bind(std::move(c), std::move(chainFun));
+ *      }
+ * @endcode
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - the previous computation is always run
+ * - if the previous computation finishes successfully, then the chain function is called
+ * - the computation returned by the function is run if the functor doesn't throw
+ * - set_done is called if either the previous computation or the next computation is cancelled
+ * - set_error is called if either of the two computations throws or the given functor throws
+ * - if set_done nor set_error are not called then set_value is called on the final receiver
+ *
+ * @see     transform(), bind_error()
+ */
+template <typename PrevComp, typename F>
+detail::bind_computation<PrevComp, F> bind(PrevComp prevComp, F chainFun) {
+    return {(PrevComp &&) prevComp, (F &&) chainFun};
+}
+
+/**
+ * @brief   Similar to bind, but takes care of the error flow
+ * @tparam  PrevComp    The type of the previous computation
+ * @tparam  F           The type of functor used to generate the second computation
+ * @param   prevComp    The previous computation we used to chain to
+ * @param   chainFun    The functor used to generate the second computation (from the prev error)
+ * @return  A computation object
+ * @details
+ *
+ * This chains two computations if the first one fails. The first computation is given directly as
+ * the first argument. If, when run, this computation succeeds, this behaves as we would just run
+ * this computation. If however, there was an error while executing the first computation, then this
+ * allows us to continue with a different computation. It calls the given functor to generate a new
+ * computation and runs this computation with the final receiver.
+ *
+ * The functor takes a std::exception_ptr as a parameter and must return a computation object.
+ *
+ * The functor must return a computation with the same value type as the first computation.
+ *
+ * The chain function will be called on the thread used by the previous computation to yield its
+ * error.
+ *
+ * If the previous computation is cancelled, or succeeds, then the transform functor will not be
+ * called. The cancellation and and the success value from the previous computation is forwarded.
+ *
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - the previous computation is always run
+ * - if the previous computation finishes with error, then the chain function is called (passing in
+ * the exception generated by the first computation)
+ * - the computation returned by the function is run (if the functor doesn't throw)
+ * - if the functor throws, then this will report the error to the final receiver
+ * - set_done is called if either the previous computation or the next computation is cancelled
+ * - set_value is called when the previous computation succeeds
+ *
+ * @see     bind(), transform()
+ */
+template <typename PrevComp, typename F>
+detail::bind_error_computation<PrevComp, F> bind_error(PrevComp prevComp, F chainFun) {
+    return {(PrevComp &&) prevComp, (F &&) chainFun};
+}
+
+// TODO: pipe operator
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/computation.hpp
+++ b/src/include/concore/computation/computation.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <concore/computation/_cpo_run_with.hpp>
+#include <concore/detail/cxx_features.hpp>
+#include <concore/detail/extra_type_traits.hpp>
+#include <concore/detail/concept_macros.hpp>
+
+#if CONCORE_CXX_HAS_CONCEPTS
+#include <concepts>
+#endif
+#include <type_traits>
+
+namespace concore {
+
+namespace computation {
+
+namespace detail {
+
+template <typename R>
+struct receiver_archetype {
+    void set_value(R) {}
+    void set_done() noexcept {}
+    void set_error(std::exception_ptr) noexcept {}
+
+    friend inline bool operator==(receiver_archetype, receiver_archetype) { return false; }
+    friend inline bool operator!=(receiver_archetype, receiver_archetype) { return true; }
+};
+
+template <>
+struct receiver_archetype<void> {
+    void set_value() {}
+    void set_done() noexcept {}
+    void set_error(std::exception_ptr) noexcept {}
+
+    friend inline bool operator==(receiver_archetype, receiver_archetype) { return false; }
+    friend inline bool operator!=(receiver_archetype, receiver_archetype) { return true; }
+};
+
+struct error_type {};
+
+error_type computation_value_type_tester(...);
+template <typename C, typename R = typename C::value_type>
+R computation_value_type_tester(C*);
+
+template <typename C>
+using computation_value_type = decltype(computation_value_type_tester(static_cast<C*>(nullptr)));
+
+template <typename C, typename R = computation_value_type<C>>
+CONCORE_CONCEPT_OR_BOOL(computation_impl) =                              //
+        (std::is_copy_constructible_v<C>)                                //
+        &&(!std::is_same_v<R, error_type>)                               //
+        &&(detail::cpo_run_with::has_run_with<C, receiver_archetype<R>>) //
+        ;
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief Concept modeling types that represent computations.
+ *
+ * @tparam C The type to check if it matches the concept
+ *
+ * @details
+ *
+ * A type T models computation if objects of type T can represent computations that result in
+ * a value of a given type, or void (in the absence of errors). The type of value computed by the
+ * computation will be indicated by the inner type `value_type`; this can be void. Semantically, one
+ * can perform two operations with such a computation object:
+ * - start the computation (i.e., executing all the steps to produce a expected value)
+ * - make use of the computed value (in the absence of errors), by being able to connect it to
+ * algorithms that extract the resulting value out of the computation.
+ *
+ * The computation either succeeds in producing a value of the expected type, or an error has
+ * occurred. If the execution was never started (i.e., cancelled), then the computation will assume
+ * a `task_cancelled` exception was thrown.
+ *
+ * We are making one important assumption: the computation can be started maximum once. From this it
+ * follows that a computation can produce maximum one value. Also, by the way computations are
+ * constructed, the value of the computation cannot be possible accessed until the computation is
+ * performed.
+ *
+ * To connect the computation with another entity and to extract the value out of the computation,
+ * one needs to pass in a receiver object, of the proper value type. This is typically done at the
+ * library level, and the end-user should not care about connecting the computation directly.
+ *
+ * The computation needs to have a run_with(receiver<value_type>) CPO. This will start the
+ * computation represented by the actual object and, when completed (either successfully or by
+ * error) will call the receiver passed in. The receiver passed in must match the value type of the
+ * current computation.
+ *
+ * Constraints enforced on the type C modeling our concept:
+ * - is copy constructable
+ * - has an inner type `value_type` (representing the resulting type of the computation)
+ * - CPO call run_with(C, Recv) is valid, where Recv is a receiver type with appropriate value type
+ *
+ * Example of a computation type:
+ * @code{.cpp}
+ *      struct fixed_value_computation {
+ *          using value_type = int;
+ *
+ *          explicit fixed_value_computation(int val): val_(val) {}
+ *
+ *          template <typename Recv>
+ *          void run_with(Recv recv) {
+ *              concore::set_value((Recv&&) recv, val_);
+ *          }
+ *      private:
+ *          int val_;
+ *      };
+ * @endcode
+ *
+ * @see task_cancelled, receiver_of
+ */
+template <typename C>
+CONCORE_CONCEPT_OR_BOOL(computation) = detail::computation_impl<C>;
+
+//! Type traits that extracts the value type from a computation. Returns an error type if the given
+//! type is not a computation.
+using detail::computation_value_type;
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/computation.hpp
+++ b/src/include/concore/computation/computation.hpp
@@ -5,9 +5,6 @@
 #include <concore/detail/extra_type_traits.hpp>
 #include <concore/detail/concept_macros.hpp>
 
-#if CONCORE_CXX_HAS_CONCEPTS
-#include <concepts>
-#endif
 #include <type_traits>
 
 namespace concore {

--- a/src/include/concore/computation/detail/algo_wrapper.hpp
+++ b/src/include/concore/computation/detail/algo_wrapper.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+//! Curring functor to help create computations with lazy "previous computation"
+template <typename CreateFun, typename T>
+struct currying_create_fun {
+    CreateFun createFun_;
+    T arg1_;
+
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& comp) const& {
+        return createFun_((Comp &&) comp, arg1_);
+    }
+
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& comp) && {
+        return ((CreateFun &&) createFun_)((Comp &&) comp, (T &&) arg1_);
+    }
+};
+
+template <typename CreateFun, typename T>
+currying_create_fun<CreateFun, T> make_currying_create_fun(CreateFun createFun, T arg1) {
+    return {(CreateFun &&) createFun, (T &&) arg1};
+}
+
+template <typename F>
+struct algo_wrapper;
+
+template <typename F1, typename F2>
+struct concat_algo_wrapper_fun {
+    algo_wrapper<F1> w1_;
+    algo_wrapper<F2> w2_;
+
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& c) const& {
+        return w2_(w1_(c));
+    }
+
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& c) && {
+        return std::move(w2_)(std::move(w1_)(c));
+    }
+};
+
+//! Wrapper for a computation algorithm. This allows the input computation to be passed in later to
+//! a computation algorithm. It allows the computation algorithm to be piped in.
+template <typename CreateFun>
+struct algo_wrapper {
+    //! The functor used to create the actual computation instance
+    CreateFun createFun_;
+
+    explicit algo_wrapper(CreateFun&& createFun)
+        : createFun_((CreateFun &&) createFun) {}
+
+    //! Call operator that will create the final computation given the input computation
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& comp) const& {
+        return createFun_((Comp &&) comp);
+    }
+    //! Call operator that will create the final computation given the input computation -- move
+    //! version
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    auto operator()(Comp&& comp) && {
+        return ((CreateFun &&) createFun_)((Comp &&) comp);
+    }
+
+    //! Pipe operator, allowing us to pipe the computation algorithms
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    friend auto operator|(Comp&& comp, algo_wrapper&& self) {
+        return std::move(self.createFun_)((Comp &&) comp);
+    }
+    template <CONCORE_CONCEPT_OR_TYPENAME(computation) Comp>
+    friend auto operator|(Comp&& comp, const algo_wrapper& self) {
+        return self.createFun_((Comp &&) comp);
+    }
+
+    //! Pipe operator, allowing us to concatenate two wrappers
+    template <typename F1>
+    friend auto operator|(algo_wrapper<F1>&& w1, algo_wrapper&& self) {
+        return make_algo_wrapper(
+                concat_algo_wrapper_fun<F1, CreateFun>{std::move(w1), std::move(self)});
+    }
+    template <typename F1>
+    friend auto operator|(const algo_wrapper<F1>& w1, const algo_wrapper& self) {
+        return make_algo_wrapper(concat_algo_wrapper_fun<F1, CreateFun>{w1, self});
+    }
+};
+
+template <typename F>
+inline auto make_algo_wrapper(F&& f) {
+    return algo_wrapper<F>((F &&) f);
+}
+
+template <typename F, typename T>
+inline auto make_algo_wrapper(F&& f, T&& arg1) {
+    auto cf = make_currying_create_fun((F &&) f, (T &&) arg1);
+    return algo_wrapper<decltype(cf)>(std::move(cf));
+}
+
+} // namespace detail
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/detail/empty_receiver.hpp
+++ b/src/include/concore/computation/detail/empty_receiver.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <exception>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+//! Receiver that doesn't do anything. Useful for computation without continuation.
+struct empty_receiver {
+    template <typename... Val>
+    void set_value(Val...) {}
+    void set_done() noexcept {}
+    void set_error(std::exception_ptr) noexcept {}
+};
+
+} // namespace detail
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/from_function.hpp
+++ b/src/include/concore/computation/from_function.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <concore/_cpo/_cpo_set_value.hpp>
+#include <concore/_cpo/_cpo_set_error.hpp>
+#include <concore/_concepts/_concepts_receiver.hpp>
+
+#include <exception>
+#include <functional>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename F>
+struct from_function_computation {
+    using value_type = std::invoke_result_t<F>;
+
+    from_function_computation(F fun)
+        : fun_((F &&) fun) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        try {
+            if constexpr (std::is_void_v<value_type>) {
+                std::invoke((F&)fun_);
+                concore::set_value((Recv &&) r);
+            } else {
+                concore::set_value((Recv &&) r, std::invoke((F&)fun_));
+            }
+        } catch (...) {
+            concore::set_error((Recv &&) r, std::current_exception());
+        }
+    }
+
+private:
+    F fun_;
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Returns a computation that just calls the given function
+ * @tparam  F   The type of function used for the computation
+ * @param   fun The function to be called as part of this computation
+ * @return  A computation object
+ * @details
+ *
+ * This creates a computation object that just calls the given function with no parameters. If the
+ * function returns a value then the computation will yield it. If the function throws, the
+ * computation will report the error. This computation can never be cancelled.
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - the given function is always run
+ * - if the function succeeds, the computation yields the result value
+ * - if the function throws, the error will be reported to the final receiver
+ * - the computation never cals set_done()
+ *
+ * @see     from_task(), just_value()
+ */
+template <typename F>
+detail::from_function_computation<F> from_function(F fun) {
+    return {(F &&) fun};
+}
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/from_function.hpp
+++ b/src/include/concore/computation/from_function.hpp
@@ -62,7 +62,7 @@ inline namespace v1 {
  * @see     from_task(), just_value()
  */
 template <typename F>
-detail::from_function_computation<F> from_function(F fun) {
+inline detail::from_function_computation<F> from_function(F fun) {
     return {(F &&) fun};
 }
 

--- a/src/include/concore/computation/from_task.hpp
+++ b/src/include/concore/computation/from_task.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#pragma once
+
+#include <concore/task.hpp>
+#include <concore/_cpo/_cpo_set_value.hpp>
+#include <concore/_cpo/_cpo_set_error.hpp>
+#include <concore/_cpo/_cpo_set_done.hpp>
+#include <concore/_cpo/_cpo_execute.hpp>
+#include <concore/_concepts/_concepts_receiver.hpp>
+#include <concore/task_cancelled.hpp>
+
+#include <exception>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename Recv>
+void call_recv_from_cont(Recv&& r, std::exception_ptr ex) {
+    if (ex) {
+        try {
+            std::rethrow_exception(ex);
+        } catch (const task_cancelled&) {
+            concore::set_done((Recv &&) r);
+        } catch (...) {
+            concore::set_error((Recv &&) r, std::move(ex));
+        }
+    } else
+        concore::set_value((Recv &&) r);
+}
+
+template <typename Recv>
+void set_recv_continuation(task& t, Recv&& r) {
+    auto inner_cont = t.get_continuation();
+    if (inner_cont) {
+        auto cont = [inner_cont, r = (Recv &&) r](std::exception_ptr ex) {
+            inner_cont(ex);
+            call_recv_from_cont((Recv &&) r, ex);
+        };
+        t.set_continuation(std::move(cont));
+    } else {
+        auto cont = [r = (Recv &&) r](
+                            std::exception_ptr ex) { call_recv_from_cont((Recv &&) r, ex); };
+        t.set_continuation(std::move(cont));
+    }
+}
+
+struct from_task_computation {
+    using value_type = void;
+
+    explicit from_task_computation(task t)
+        : task_(std::move(t)) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        set_recv_continuation(task_, (Recv &&) r);
+        task_();
+    }
+
+private:
+    task task_;
+};
+
+template <typename E>
+struct from_task_computation_exec {
+    using value_type = void;
+
+    from_task_computation_exec(task t, E exec)
+        : task_(std::move(t))
+        , exec_((E &&) exec) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        set_recv_continuation(task_, (Recv &&) r);
+
+        concore::execute((E &&) exec_, std::move(task_));
+    }
+
+private:
+    task task_;
+    E exec_;
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Returns a computation that executes the given task
+ * @tparam  E       The type of executor to use to execute the task
+ * @param   t       The task to be executed
+ * @param   exec    The executor to be used when executing the task (optional)
+ * @return  A computation object
+ * @details
+ *
+ * This creates a computation object that, whenever run, will execute the given task; if an executor
+ * is given, the task will be used in the given executor. The receiver will be called accordingly to
+ * the result presented at the continuation of the task.
+ *
+ * Note that the task might create subtasks and move the continuation to one of these subtasks. This
+ * means that the continuation may be called asynchronously on a completely different threads, and
+ * thus the receiver will be called in the same way as well.
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - if the task run with success, the computation will eventually call set_value() on the given
+ * receiver
+ * - if the task yields an error, the computation will call set_error() passing the exception
+ * - if the task is cancelled, the computation will call set_done() on the receiver
+ *
+ * @see     task
+ */
+template <typename E>
+detail::from_task_computation_exec<E> from_task(task t, E exec) {
+    return detail::from_task_computation_exec<E>{std::move(t), (E &&) exec};
+}
+
+detail::from_task_computation from_task(task t) {
+    return detail::from_task_computation{std::move(t)};
+}
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/from_task.hpp
+++ b/src/include/concore/computation/from_task.hpp
@@ -12,7 +12,7 @@ namespace computation {
 namespace detail {
 
 template <typename Recv>
-void set_recv_continuation(task& t, Recv&& r) {
+inline void set_recv_continuation(task& t, Recv&& r) {
     auto inner_cont = t.get_continuation();
     if (inner_cont) {
         t.set_continuation(concore::detail::call_prev_and_recv_continuation<Recv, void>{
@@ -25,7 +25,7 @@ void set_recv_continuation(task& t, Recv&& r) {
 struct from_task_computation {
     using value_type = void;
 
-    explicit from_task_computation(task t)
+    from_task_computation(task t)
         : task_(std::move(t)) {}
 
     template <typename Recv>
@@ -89,13 +89,11 @@ inline namespace v1 {
  * @see     task
  */
 template <typename E>
-detail::from_task_computation_exec<E> from_task(task t, E exec) {
-    return detail::from_task_computation_exec<E>{std::move(t), (E &&) exec};
+inline detail::from_task_computation_exec<E> from_task(task t, E exec) {
+    return {std::move(t), (E &&) exec};
 }
 
-detail::from_task_computation from_task(task t) {
-    return detail::from_task_computation{std::move(t)};
-}
+inline detail::from_task_computation from_task(task t) { return {std::move(t)}; }
 
 } // namespace v1
 } // namespace computation

--- a/src/include/concore/computation/just_value.hpp
+++ b/src/include/concore/computation/just_value.hpp
@@ -55,12 +55,12 @@ inline namespace v1 {
  * @see     just_void()
  */
 template <typename T>
-detail::just_value_computation<T> just_value(T val) {
+inline detail::just_value_computation<T> just_value(T val) {
     return detail::just_value_computation<T>{(T &&) val};
 }
 
 //! @overload
-detail::just_value_computation<void> just_value() { return {}; }
+inline detail::just_value_computation<void> just_value() { return {}; }
 
 /**
  * @brief   Returns a computation that just yields nothing
@@ -72,7 +72,7 @@ detail::just_value_computation<void> just_value() { return {}; }
  *
  * @see just_value()
  */
-detail::just_value_computation<void> just_void() { return {}; }
+inline detail::just_value_computation<void> just_void() { return {}; }
 
 } // namespace v1
 } // namespace computation

--- a/src/include/concore/computation/just_value.hpp
+++ b/src/include/concore/computation/just_value.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <concore/_cpo/_cpo_set_value.hpp>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename T>
+struct just_value_computation {
+    using value_type = T;
+
+    explicit just_value_computation(T val)
+        : val_((T &&) val) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        concore::set_value((Recv &&) r, (T &&) val_);
+    }
+
+private:
+    T val_;
+};
+
+template <>
+struct just_value_computation<void> {
+    using value_type = void;
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        concore::set_value((Recv &&) r);
+    }
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Returns a computation that just yields the given value
+ * @tparam  T   The type of the value to yield
+ * @param   val The value to yield
+ * @return  A computation object
+ * @details
+ *
+ * This creates a computation object that, whenever run, will yield the value passed here.
+ * It is useful for starting computation chains.
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - when run, the computation will call set_value() passing the value given here
+ * - the computation will not throw if the value has noexcept copy/move ctors
+ * - the computation will never call set_done()
+ *
+ * @see     just_void()
+ */
+template <typename T>
+detail::just_value_computation<T> just_value(T val) {
+    return detail::just_value_computation<T>{(T &&) val};
+}
+
+//! @overload
+detail::just_value_computation<void> just_value() { return {}; }
+
+/**
+ * @brief   Returns a computation that just yields nothing
+ * @return  A computation object
+ * @details
+ *
+ * Similar to just_value(), but instead of yielding a value it will just yield nothing. That is, it
+ * will call the receiver with no value.
+ *
+ * @see just_value()
+ */
+detail::just_value_computation<void> just_void() { return {}; }
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/on.hpp
+++ b/src/include/concore/computation/on.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <concore/computation/computation.hpp>
+#include <concore/detail/call_recv_continuation.hpp>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename R, typename E, typename ValT>
+struct on_computation_receiver {
+    R finalRecv_;
+    E exec_;
+
+    template <typename... Val>
+    void set_value(Val... val) { // zero or one parameter
+        // Encapsulate the call to the final receiver in a task continuation
+        auto cont = concore::detail::call_recv_continuation<R, ValT>{
+                (R &&) finalRecv_, (Val &&) val...};
+        // Execute the task in the context of the given executor
+        concore::execute(exec_, task{[] {}, {}, std::move(cont)});
+    }
+    void set_done() noexcept { concore::set_done((R &&) finalRecv_); }
+    void set_error(std::exception_ptr e) noexcept { concore::set_error((R &&) finalRecv_, e); }
+};
+
+template <typename PrevComp, typename E>
+struct on_computation {
+    using value_type = typename PrevComp::value_type;
+
+    on_computation(PrevComp prevComp, E exec)
+        : prevComp_((PrevComp &&) prevComp)
+        , exec_((E &&) exec) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        using recv_type = on_computation_receiver<Recv, E, value_type>;
+        auto recv = recv_type{(Recv &&) r, (E &&) exec_};
+        concore::computation::run_with((PrevComp &&) prevComp_, std::move(recv));
+    }
+
+private:
+    PrevComp prevComp_;
+    E exec_;
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Moves the computation to a different executor
+ * @tparam  PrevComp    The type of the previous computation
+ * @tparam  E           The type of executor to move the computation to
+ * @param   prevComp    The previous computation happening before the switching of executors
+ * @param   exec        The executor to move computation to
+ * @return  A computation object
+ * @details
+ *
+ * This moves the result of the previous computation to a different executor. It is typically used
+ * whenever other computation parts need to happen which are chained on top of this.
+ *
+ * Whenever possible, only the calls to set_value() are moved to an executor. If there are errors
+ * or if the computation is cancelled, then those notifications may not be moved to the given
+ * executor.
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - the previous computation is always run
+ * - the previous computation is run in the thread in which this computation is started
+ * - whenever the previous computation finishes successfully, this will also notify success, but
+ * will do it from inside the given executor.
+ * - if the previous computation finished with error or it's cancelled, then this will forward the
+ * error/cancellation
+ * - the forwarding of the error/cancellation typically doesn't happen on the given executor
+ * - if the executor throws, this will report the error
+ * - if the executor cancels execution, this will report the cancellation
+ *
+ * @see     transform(), bind_error()
+ */
+template <typename PrevComp, typename E>
+detail::on_computation<PrevComp, E> on(PrevComp prevComp, E exec) {
+    return {(PrevComp &&) prevComp, (E &&) exec};
+}
+
+// TODO: pipe operator
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/on.hpp
+++ b/src/include/concore/computation/on.hpp
@@ -80,7 +80,7 @@ inline namespace v1 {
  * @see     transform(), bind_error()
  */
 template <typename PrevComp, typename E>
-detail::on_computation<PrevComp, E> on(PrevComp prevComp, E exec) {
+inline detail::on_computation<PrevComp, E> on(PrevComp prevComp, E exec) {
     return {(PrevComp &&) prevComp, (E &&) exec};
 }
 

--- a/src/include/concore/computation/run.hpp
+++ b/src/include/concore/computation/run.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <concore/computation/computation.hpp>
+#include <concore/computation/detail/empty_receiver.hpp>
+
+namespace concore {
+namespace computation {
+
+inline namespace v1 {
+
+/**
+ * @brief   Runs the given computation
+ * @tparam  Comp    The type of the computation to be run
+ * @tparam  Recv    The type of receiver used to get completion notification (optional)
+ * @param   comp    The computation to be run
+ * @param   recv    The receiver that gets the completion notification (optional)
+ * @details
+ *
+ * This is semantically equivalent with the `run_with` CPO. It runs a computation and sends the
+ * completion notification to the given receiver. If no receiver is passed here, then there will be
+ * no notification of completion.
+ *
+ *
+ * Post-conditions:
+ * - same as run_with
+ *
+ * @see     run_with(), run_on()
+ */
+template <typename Comp, typename Recv>
+inline void run(Comp comp, Recv recv) {
+    return run_with((Comp &&) comp, (Recv &&) recv);
+}
+
+//! @overload
+template <typename Comp>
+inline void run(Comp comp) {
+    return run_with((Comp &&) comp, detail::empty_receiver{});
+}
+
+/**
+ * @brief   Runs (starts) the given computation on the given executor
+ * @tparam  Exec    The type of executor to run the computation from
+ * @tparam  Comp    The type of the computation to be run
+ * @tparam  Recv    The type of receiver used to get completion notification (optional)
+ * @param   exec    The executor to run the computation on
+ * @param   comp    The computation to be run
+ * @param   recv    The receiver that gets the completion notification (optional)
+ * @details
+ *
+ * Similar to run(), this will run the computation. The difference is that this will use the given
+ * executor to start the computation run. Please note that the computation is started on the given
+ * executor, but it may finish outside (e.g., if 'on()' was called while building the computation).
+ *
+ * If the executor cannot enqueue the running of the computation this function it will throw.
+ *
+ * Post-conditions:
+ * - same as run_with, for executing the computation
+ * - the computation is started on the given executor
+ * - if the executor is cancelled or it throws, this function will also throw
+ *
+ * @see     run_with(), run()
+ */
+template <typename Exec, typename Comp, typename Recv>
+inline void run_on(Exec exec, Comp comp, Recv recv) {
+    auto task_fun = [comp = (Comp &&) comp, recv = (Recv &&) recv]() mutable {
+        run_with((Comp &&) comp, (Recv &&) recv);
+    };
+    concore::execute((Exec &&) exec, task{std::move(task_fun)});
+}
+
+//! @overload
+template <typename Exec, typename Comp>
+inline void run_on(Exec exec, Comp comp) {
+    auto task_fun = [comp = (Comp &&) comp]() mutable {
+        run_with((Comp &&) comp, detail::empty_receiver{});
+    };
+    concore::execute((Exec &&) exec, std::move(task_fun));
+}
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/to_task.hpp
+++ b/src/include/concore/computation/to_task.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <concore/computation/computation.hpp>
+#include <concore/task.hpp>
+#include <concore/task_cancelled.hpp>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+struct empty_recv {
+    template <typename... Val>
+    void set_value(Val...) {}
+    void set_done() noexcept {}
+    void set_error(std::exception_ptr) noexcept {}
+};
+
+struct to_task_recv {
+    task_continuation_function cont_;
+
+    template <typename... Val>
+    void set_value(Val... val) { // zero or one parameter
+        cont_({});
+    }
+    void set_done() noexcept {
+        try {
+            throw task_cancelled{};
+        } catch (...) {
+            try {
+                cont_(std::current_exception());
+            } catch (...) {
+            }
+        }
+    }
+    void set_error(std::exception_ptr ex) noexcept {
+        try {
+            cont_(ex);
+        } catch (...) {
+        }
+    }
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Transform a computation into a task
+ * @tparam  Comp    The type of the computation to be transformed into a task
+ * @param   comp    The computation to be transformed into a task
+ * @param   grp     The group in which to create the task
+ * @param   cont    The continuation to be called whenever the computation is done
+ * @return  A task that runs the computation
+ * @details
+ *
+ * This takes a computation and returns a task that executes the computation. The task will be
+ * created with the given group (if non-empty). The given continuation functor will be called
+ * whenever the computation is completed. Please note, however, that the computation will not be
+ * directly attached to the task.
+ *
+ * If the computation yields a value, the task will drop it.
+ *
+ * Post-conditions:
+ * - the returned task will run the computation whenever it's executed
+ * - the continuation functor will be called whenever the computation finishes
+ * - if the continuation succeeds, the continuation will be called with an empty exception ptr
+ * - if the continuation finishes with an error, that error will be passed to the continuation
+ * - if the continuation is cancelled, the continuation will be called with task_cancelled exception
+ *
+ * @see     from_task(), computation
+ */
+template <typename Comp>
+inline task to_task(Comp comp, task_group grp = {}, task_continuation_function cont = {}) {
+    static_assert(concore::computation::computation<Comp>, "given type is not a computation");
+    if (cont) {
+        auto task_fun = [comp = (Comp &&) comp, cont = std::move(cont)]() mutable {
+            run_with((Comp &&) comp, detail::to_task_recv{std::move(cont)});
+        };
+        return {std::move(task_fun), std::move(grp)};
+    } else {
+        auto task_fun = [comp = (Comp &&) comp]() mutable {
+            run_with((Comp &&) comp, detail::empty_recv{});
+        };
+        return {std::move(task_fun), std::move(grp)};
+    }
+}
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/to_task.hpp
+++ b/src/include/concore/computation/to_task.hpp
@@ -3,17 +3,11 @@
 #include <concore/computation/computation.hpp>
 #include <concore/task.hpp>
 #include <concore/task_cancelled.hpp>
+#include <concore/computation/detail/empty_receiver.hpp>
 
 namespace concore {
 namespace computation {
 namespace detail {
-
-struct empty_recv {
-    template <typename... Val>
-    void set_value(Val...) {}
-    void set_done() noexcept {}
-    void set_error(std::exception_ptr) noexcept {}
-};
 
 struct to_task_recv {
     task_continuation_function cont_;
@@ -79,7 +73,7 @@ inline task to_task(Comp comp, task_group grp = {}, task_continuation_function c
         return {std::move(task_fun), std::move(grp)};
     } else {
         auto task_fun = [comp = (Comp &&) comp]() mutable {
-            run_with((Comp &&) comp, detail::empty_recv{});
+            run_with((Comp &&) comp, detail::empty_receiver{});
         };
         return {std::move(task_fun), std::move(grp)};
     }

--- a/src/include/concore/computation/transform.hpp
+++ b/src/include/concore/computation/transform.hpp
@@ -103,7 +103,7 @@ inline namespace v1 {
  * @see     bind(), bind_error()
  */
 template <typename PrevComp, typename F>
-detail::transform_computation<PrevComp, F> transform(PrevComp prevComp, F trFun) {
+inline detail::transform_computation<PrevComp, F> transform(PrevComp prevComp, F trFun) {
     return {(PrevComp &&) prevComp, (F &&) trFun};
 }
 

--- a/src/include/concore/computation/transform.hpp
+++ b/src/include/concore/computation/transform.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#pragma once
-
-#include <concore/task.hpp>
 #include <concore/_cpo/_cpo_set_value.hpp>
 #include <concore/_cpo/_cpo_set_error.hpp>
 #include <concore/_cpo/_cpo_set_done.hpp>
@@ -50,7 +47,7 @@ template <typename PrevComp, typename F>
 struct transform_computation {
     using value_type = typename transform_result<typename PrevComp::value_type, F>::type;
 
-    explicit transform_computation(PrevComp prevComp, F trFun)
+    transform_computation(PrevComp prevComp, F trFun)
         : prevComp_((PrevComp &&) prevComp)
         , trFun_((F &&) trFun) {}
 
@@ -75,7 +72,7 @@ inline namespace v1 {
  * @brief   Returns a computation that transforms the result of a previous computation
  * @tparam  PrevComp    The type of the previous computation
  * @tparam  F           The type of functor used to transform the previous result
- * @param   prevComp    The prvious computation that needs to be transformed
+ * @param   prevComp    The previous computation that needs to be transformed
  * @param   trFun       The functor used to transform the result of the previous computation
  * @return  A computation object
  * @details
@@ -107,7 +104,7 @@ inline namespace v1 {
  */
 template <typename PrevComp, typename F>
 detail::transform_computation<PrevComp, F> transform(PrevComp prevComp, F trFun) {
-    return detail::transform_computation<PrevComp, F>{(PrevComp &&) prevComp, (F &&) trFun};
+    return {(PrevComp &&) prevComp, (F &&) trFun};
 }
 
 // TODO: pipe operator

--- a/src/include/concore/computation/transform.hpp
+++ b/src/include/concore/computation/transform.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#pragma once
+
+#include <concore/task.hpp>
+#include <concore/_cpo/_cpo_set_value.hpp>
+#include <concore/_cpo/_cpo_set_error.hpp>
+#include <concore/_cpo/_cpo_set_done.hpp>
+
+#include <exception>
+#include <functional>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+template <typename ParamT, typename F>
+struct transform_result {
+    using type = std::invoke_result_t<F, ParamT>;
+};
+
+template <typename F>
+struct transform_result<void, F> {
+    using type = std::invoke_result_t<F>;
+};
+
+template <typename OutT, typename F, typename R>
+struct transform_computation_receiver {
+    R finalRecv_;
+    F trFun_;
+
+    template <typename... Val>
+    void set_value(Val... val) { // zero or one parameter
+        try {
+            if constexpr (std::is_void_v<OutT>) {
+                std::invoke((F&)trFun_, (Val &&) val...);
+                concore::set_value((R &&) finalRecv_);
+            } else {
+                concore::set_value((R &&) finalRecv_, std::invoke((F&)trFun_, (Val &&) val...));
+            }
+        } catch (...) {
+            concore::set_error((R &&) finalRecv_, std::current_exception());
+        }
+    }
+    void set_done() noexcept { concore::set_done((R &&) finalRecv_); }
+    void set_error(std::exception_ptr e) noexcept { concore::set_error((R &&) finalRecv_, e); }
+};
+
+template <typename PrevComp, typename F>
+struct transform_computation {
+    using value_type = typename transform_result<typename PrevComp::value_type, F>::type;
+
+    explicit transform_computation(PrevComp prevComp, F trFun)
+        : prevComp_((PrevComp &&) prevComp)
+        , trFun_((F &&) trFun) {}
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        static_assert(concore::receiver<Recv>, "given type is not a receiver");
+        using recv_type = transform_computation_receiver<value_type, F, Recv>;
+        auto recv = recv_type{(Recv &&) r, (F &&) trFun_};
+        concore::computation::run_with((PrevComp &&) prevComp_, std::move(recv));
+    }
+
+private:
+    PrevComp prevComp_;
+    F trFun_;
+};
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Returns a computation that transforms the result of a previous computation
+ * @tparam  PrevComp    The type of the previous computation
+ * @tparam  F           The type of functor used to transform the previous result
+ * @param   prevComp    The prvious computation that needs to be transformed
+ * @param   trFun       The functor used to transform the result of the previous computation
+ * @return  A computation object
+ * @details
+ *
+ * This creates a computation object that, whenever run, will execute the previous computation, gets
+ * its value and transforms it with the given function and yields the final result. This woks also
+ * in the cases in which the previous computation yeids void, or if the transform function returns
+ * void; in this cases, this computation can be used to represent "do this, then that" (where "that"
+ * is represented as a functor).
+ *
+ * The transformation function will be called on the thread used by the previous computation to
+ * yield its result.
+ *
+ * If the previous computation is cancelled, or has an error, then the transform functor will not be
+ * called, and the done/error state will be just forwarded.
+ *
+ * Post-conditions:
+ * - the returned type models the `computation` concept
+ * - the previous computation is always run
+ * - if the previous computation finishes successfully, then the transform function is called
+ * - if both the previous computation succeeds and the transform functor doesn't throw, set_value()
+ * is called on the final receiver
+ * - if the transform functor throws (if executed), set_error() will be called
+ * - if the previous computation is not successful, then the transform functor is not called
+ * - if the previous computation is not successful, then the error/cancellation is forwarded to the
+ * final receiver
+ *
+ * @see     bind(), bind_error()
+ */
+template <typename PrevComp, typename F>
+detail::transform_computation<PrevComp, F> transform(PrevComp prevComp, F trFun) {
+    return detail::transform_computation<PrevComp, F>{(PrevComp &&) prevComp, (F &&) trFun};
+}
+
+// TODO: pipe operator
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/computation/wait.hpp
+++ b/src/include/concore/computation/wait.hpp
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <concore/computation/computation.hpp>
+#include <concore/spawn.hpp>
+#include <concore/task_cancelled.hpp>
+
+namespace concore {
+namespace computation {
+namespace detail {
+
+struct wait_recv_base {
+    task_group grp_;
+    std::exception_ptr& ex_;
+
+    wait_recv_base(task_group grp, std::exception_ptr& ex)
+        : grp_(std::move(grp))
+        , ex_(ex) {}
+
+    void set_value() { concore::detail::task_group_access::on_task_destroyed(grp_); }
+    void set_done() noexcept {
+        try {
+            throw task_cancelled{};
+        } catch (...) {
+            ex_ = std::current_exception();
+        }
+        concore::detail::task_group_access::on_task_destroyed(grp_);
+    }
+    void set_error(std::exception_ptr ex) noexcept {
+        ex_ = ex;
+        concore::detail::task_group_access::on_task_destroyed(grp_);
+    }
+};
+
+template <typename T>
+struct wait_recv : wait_recv_base {
+    T* val_;
+
+    wait_recv(task_group grp, std::exception_ptr& ex, T* val)
+        : wait_recv_base(std::move(grp), ex)
+        , val_(val) {}
+
+    void set_value(T val) {
+        *val_ = (T &&) val;
+        wait_recv_base::set_value();
+    }
+};
+
+template <>
+struct wait_recv<void> : wait_recv_base {
+    wait_recv(task_group grp, std::exception_ptr& ex, void* = nullptr)
+        : wait_recv_base(std::move(grp), ex) {}
+};
+
+template <typename Comp, typename ValT>
+inline void do_wait(Comp comp, ValT* res) {
+    // Create a group and keep it busy
+    auto grp = concore::task_group::create();
+    concore::detail::task_group_access::on_task_created(grp);
+
+    // Start the computation and retain the results
+    std::exception_ptr ex;
+    run_with((Comp &&) comp, wait_recv{grp, ex, res});
+
+    // Wait until the computation is completely done
+    concore::wait(grp);
+
+    // If there is an error or cancellation, rethrow here
+    if (ex)
+        std::rethrow_exception(ex);
+}
+
+} // namespace detail
+
+inline namespace v1 {
+
+/**
+ * @brief   Runs a computation and wait for its result
+ * @tparam  Comp    The type of the computation to run
+ * @param   comp    The computation that need to be run
+ * @return  The result of the computation
+ * @details
+ *
+ * This will run a computation and wait for the result. If the computation yields a non-void value,
+ * this function will return the value yielded by the computation. If the computation results with
+ * an error the error is thrown in the context of this function. If the computation is cancelled
+ * this function will throw task_cancelled.
+ *
+ * The waiting employed here is a busy-wait. While the computation is not yet done and there are
+ * other tasks that can be executed, these will begin to execute. This will try to keep the
+ * throughput high, but it may have latency issues.
+ *
+ * Post-conditions:
+ * - if the computation yields a non-void value, the result of this will be the value type of the
+ * computation
+ * - if the computation has a value type of void, this will return void
+ * - if the computation yields a non-void value, this function will return it
+ * - if the computation ends with an error, this function will throw that error
+ * - if the computation is canceled, this function will throw task_cancelled
+ * - the computation is run & consumed before the function exists
+ *
+ * @see     just_value(), transform(), computation
+ */
+template <typename Comp>
+inline typename Comp::value_type wait(Comp comp) {
+    using res_t = typename Comp::value_type;
+    if constexpr (std::is_void_v<res_t>) {
+        detail::do_wait<Comp, res_t>((Comp &&) comp, nullptr);
+    } else {
+        res_t res;
+        detail::do_wait<Comp, res_t>((Comp &&) comp, &res);
+        return res;
+    }
+}
+
+} // namespace v1
+} // namespace computation
+} // namespace concore

--- a/src/include/concore/detail/call_recv_continuation.hpp
+++ b/src/include/concore/detail/call_recv_continuation.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <concore/_cpo/_cpo_set_value.hpp>
+#include <concore/_cpo/_cpo_set_error.hpp>
+#include <concore/_cpo/_cpo_set_done.hpp>
+#include <concore/task_cancelled.hpp>
+
+#include <exception>
+
+namespace concore {
+namespace detail {
+
+template <typename Recv, typename... ValT> // zero or one set_value parameters
+void call_recv_on_continuation(std::exception_ptr ex, Recv r, ValT... vals) noexcept {
+    if (ex) {
+        try {
+            std::rethrow_exception(ex);
+        } catch (const task_cancelled&) {
+            concore::set_done((Recv &&) r);
+        } catch (...) {
+            concore::set_error((Recv &&) r, std::move(ex));
+        }
+    } else {
+        try {
+            concore::set_value((Recv &&) r, (ValT &&) vals...);
+        } catch (...) {
+            concore::set_error((Recv &&) r, std::current_exception());
+        }
+    }
+}
+
+template <typename Recv, typename ValT>
+struct call_recv_continuation {
+    Recv recv_;
+    ValT val_;
+
+    void operator()(std::exception_ptr ex) noexcept {
+        call_recv_on_continuation(ex, (Recv &&) recv_, (ValT &&) val_);
+    }
+};
+
+template <typename Recv>
+struct call_recv_continuation<Recv, void> {
+    Recv recv_;
+
+    void operator()(std::exception_ptr ex) noexcept {
+        call_recv_on_continuation(ex, (Recv &&) recv_);
+    }
+};
+
+template <typename Recv, typename ValT>
+struct call_prev_and_recv_continuation {
+    task_continuation_function prev_;
+    Recv recv_;
+    ValT val_;
+
+    void operator()(std::exception_ptr ex) noexcept {
+        prev_(ex);
+        call_recv_on_continuation(ex, (Recv &&) recv_, (ValT &&) val_);
+    }
+};
+
+template <typename Recv>
+struct call_prev_and_recv_continuation<Recv, void> {
+    task_continuation_function prev_;
+    Recv recv_;
+
+    void operator()(std::exception_ptr ex) noexcept {
+        prev_(ex);
+        call_recv_on_continuation(ex, (Recv &&) recv_);
+    }
+};
+
+// template <typename Recv>
+// void call_recv_from_cont(Recv&& r, std::exception_ptr ex) {
+//     if (ex) {
+//         try {
+//             std::rethrow_exception(ex);
+//         } catch (const task_cancelled&) {
+//             concore::set_done((Recv &&) r);
+//         } catch (...) {
+//             concore::set_error((Recv &&) r, std::move(ex));
+//         }
+//     } else
+//         concore::set_value((Recv &&) r);
+// }
+//
+// template <typename Recv>
+// void set_recv_continuation(task& t, Recv&& r) {
+//     auto inner_cont = t.get_continuation();
+//     if (inner_cont) {
+//         auto cont = [inner_cont, r = (Recv &&) r](std::exception_ptr ex) {
+//             inner_cont(ex);
+//             call_recv_from_cont((Recv &&) r, ex);
+//         };
+//         t.set_continuation(std::move(cont));
+//     } else {
+//         auto cont = [r = (Recv &&) r](
+//                             std::exception_ptr ex) { call_recv_from_cont((Recv &&) r, ex); };
+//         t.set_continuation(std::move(cont));
+//     }
+// }
+
+} // namespace detail
+} // namespace concore

--- a/src/include/concore/task.hpp
+++ b/src/include/concore/task.hpp
@@ -253,7 +253,7 @@ public:
      * This does not invalidate the task object, by itself. Theoretically, this can be called
      * multiple times in a row.
      */
-    void operator()();
+    void operator()() noexcept;
 
     /**
      * @brief Gets the continuation function stored in this task (may be empty)

--- a/src/lib/task.cpp
+++ b/src/lib/task.cpp
@@ -12,7 +12,7 @@ thread_local task* g_current_task{nullptr};
 
 inline namespace v1 {
 
-void task::operator()() {
+void task::operator()() noexcept {
     // Mark this as the currently executing task
     detail::g_current_task = this;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(func_sourceFiles
     "func/std/test_sender_done_error.cpp"
 
     "func/computation/test_computation.cpp"
+    "func/computation/test_computation_algos.cpp"
 
     "func/profiling_helper_test.cpp" # Must be last
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,8 @@ set(func_sourceFiles
     "func/std/test_sender_algo.cpp"
     "func/std/test_sender_done_error.cpp"
 
+    "func/computation/test_computation.cpp"
+
     "func/profiling_helper_test.cpp" # Must be last
 )
 

--- a/test/func/computation/test_computation.cpp
+++ b/test/func/computation/test_computation.cpp
@@ -1,0 +1,121 @@
+#include <catch2/catch.hpp>
+
+#include <concore/computation/computation.hpp>
+
+#include <string>
+
+template <typename C, typename R>
+void ensure_computation() {
+    static_assert(concore::computation::computation<C>, "Given type is not a computation");
+    static_assert(std::is_same_v<typename C::value_type, R>, "Invalid value_type in computation");
+}
+
+template <typename C>
+void ensure_not_computation() {
+    static_assert(!concore::computation::computation<C>,
+            "Given type is a computation, when we expect it not to be");
+}
+
+template <typename R>
+struct simple_computation {
+    using value_type = R;
+
+    template <typename Recv>
+    void run_with(Recv recv) noexcept {
+        recv.set_done();
+    }
+};
+
+struct bad_computation1 {
+    template <typename Recv>
+    void run_with(Recv recv) noexcept {
+        recv.set_done();
+    }
+};
+
+struct bad_computation2 {
+    using value_type = int;
+};
+
+struct comp_val {
+    using value_type = int;
+
+    template <typename Recv>
+    void run_with(Recv r) {
+        ((Recv &&) r).set_value(10);
+    }
+};
+
+struct comp_with_tag_invoke {
+    using value_type = int;
+};
+template <typename Recv>
+void tag_invoke(concore::computation::run_with_t, comp_with_tag_invoke, Recv r) {
+    r.set_value(11);
+}
+
+struct comp_with_outer_fun {
+    using value_type = int;
+};
+
+template <typename Recv>
+void run_with(comp_with_outer_fun, Recv r) {
+    r.set_value(12);
+}
+
+struct test_int_receiver {
+    int* res;
+    void set_value(int v) { *res = v; }
+    void set_done() { FAIL("set_done() called"); }
+    void set_error(std::exception) { FAIL("set_error() called"); }
+};
+
+TEST_CASE("a simple type that matches the computation concept", "[computation]") {
+    // Check that some simple computation objects match the concept
+    ensure_computation<simple_computation<void>, void>();
+    ensure_computation<simple_computation<int>, int>();
+    ensure_computation<simple_computation<std::string>, std::string>();
+
+    // Check a few classes that do not match the concept
+    ensure_not_computation<bad_computation1>();
+    ensure_not_computation<bad_computation2>();
+
+    using namespace concore::computation;
+    using namespace concore::computation::detail;
+    using C = simple_computation<void>;
+    using R = typename C::value_type;
+    using Recv = receiver_archetype<void>;
+    // static_assert(cpo_run_with::has_run_with<bad_computation2, int>, "test");
+    static_assert(std::is_void_v<computation_value_type<C>>, "test");
+    static_assert(std::is_void_v<R>, "test");
+    static_assert(std::is_same_v<Recv, receiver_archetype<void>>, "test");
+    static_assert(detail::cpo_run_with::has_run_with<C, Recv>, "test2");
+    static_assert(detail::cpo_run_with::meets_inner_fun<C, Recv>, "test3");
+}
+
+TEST_CASE("some types do not match computation concept", "[computation]") {
+    ensure_not_computation<bad_computation1>();
+    ensure_not_computation<bad_computation2>();
+}
+
+TEST_CASE("computation using inner method CPO", "[computation]") {
+    ensure_computation<comp_val, int>();
+
+    int res{0};
+    concore::computation::run_with(comp_val{}, test_int_receiver{&res});
+    REQUIRE(res == 10);
+}
+TEST_CASE("computation using tag_invoke CPO", "[computation]") {
+    ensure_computation<comp_with_tag_invoke, int>();
+
+    int res{0};
+    concore::computation::run_with(comp_with_tag_invoke{}, test_int_receiver{&res});
+    REQUIRE(res == 11);
+}
+TEST_CASE("computation using outer function CPO", "[computation]") {
+    ensure_computation<comp_with_outer_fun, int>();
+
+    int res{0};
+    concore::computation::run_with(comp_with_outer_fun{}, test_int_receiver{&res});
+    REQUIRE(res == 12);
+}

--- a/test/func/computation/test_computation_algos.cpp
+++ b/test/func/computation/test_computation_algos.cpp
@@ -1,0 +1,63 @@
+#include <catch2/catch.hpp>
+
+#include <concore/computation/computation.hpp>
+#include <concore/computation/just_value.hpp>
+
+#include <string>
+
+template <typename C, typename R>
+void ensure_computation() {
+    static_assert(concore::computation::computation<C>, "Given type is not a computation");
+    static_assert(std::is_same_v<typename C::value_type, R>, "Invalid value_type in computation");
+}
+
+template <typename T>
+struct test_value_receiver {
+    T* res;
+    void set_value(T v) { *res = v; }
+    void set_done() { FAIL("set_done() called"); }
+    void set_error(std::exception) { FAIL("set_error() called"); }
+};
+
+struct test_void_receiver {
+    bool* called;
+    void set_value() { *called = true; }
+    void set_done() { FAIL("set_done() called"); }
+    void set_error(std::exception) { FAIL("set_error() called"); }
+};
+
+TEST_CASE("just_value(int) is a computation that yields the specified value", "[computation]") {
+    auto c = concore::computation::just_value(10);
+    ensure_computation<decltype(c), int>();
+
+    int res{0};
+    concore::computation::run_with(c, test_value_receiver<int>{&res});
+    REQUIRE(res == 10);
+}
+
+TEST_CASE("just_value(string) is a computation that yields the specified value", "[computation]") {
+    auto c = concore::computation::just_value(std::string{"Hello, world!"});
+    ensure_computation<decltype(c), std::string>();
+
+    std::string res;
+    concore::computation::run_with(c, test_value_receiver<std::string>{&res});
+    REQUIRE(res == "Hello, world!");
+}
+
+TEST_CASE("just_value() is a computation that yields nothing", "[computation]") {
+    auto c = concore::computation::just_value();
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_void_receiver{&called});
+    REQUIRE(called);
+}
+
+TEST_CASE("just_void() is a computation that yields nothing", "[computation]") {
+    auto c = concore::computation::just_void();
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_void_receiver{&called});
+    REQUIRE(called);
+}

--- a/test/func/computation/test_computation_algos.cpp
+++ b/test/func/computation/test_computation_algos.cpp
@@ -2,8 +2,14 @@
 
 #include <concore/computation/computation.hpp>
 #include <concore/computation/just_value.hpp>
+#include <concore/computation/from_task.hpp>
+#include <concore/as_receiver.hpp>
+#include <concore/inline_executor.hpp>
+#include <concore/thread_pool.hpp>
+#include <test_common/throwing_executor.hpp>
 
 #include <string>
+#include <atomic>
 
 template <typename C, typename R>
 void ensure_computation() {
@@ -15,15 +21,29 @@ template <typename T>
 struct test_value_receiver {
     T* res;
     void set_value(T v) { *res = v; }
-    void set_done() { FAIL("set_done() called"); }
-    void set_error(std::exception) { FAIL("set_error() called"); }
+    void set_done() noexcept { FAIL("set_done() called"); }
+    void set_error(std::exception_ptr) noexcept { FAIL("set_error() called"); }
 };
 
 struct test_void_receiver {
     bool* called;
     void set_value() { *called = true; }
-    void set_done() { FAIL("set_done() called"); }
-    void set_error(std::exception) { FAIL("set_error() called"); }
+    void set_done() noexcept { FAIL("set_done() called"); }
+    void set_error(std::exception_ptr) noexcept { FAIL("set_error() called"); }
+};
+
+struct test_error_receiver {
+    bool* called;
+    void set_value() { FAIL("set_value() called"); }
+    void set_done() noexcept { FAIL("set_done() called"); }
+    void set_error(std::exception_ptr) noexcept { *called = true; }
+};
+
+struct test_done_receiver {
+    bool* called;
+    void set_value() { FAIL("set_value() called"); }
+    void set_done() noexcept { *called = true; }
+    void set_error(std::exception_ptr) noexcept { FAIL("set_error() called"); }
 };
 
 TEST_CASE("just_value(int) is a computation that yields the specified value", "[computation]") {
@@ -60,4 +80,129 @@ TEST_CASE("just_void() is a computation that yields nothing", "[computation]") {
     bool called{false};
     concore::computation::run_with(c, test_void_receiver{&called});
     REQUIRE(called);
+}
+
+TEST_CASE("just_task with a no-error task will call set_value", "[computation]") {
+    concore::task t{[] {}};
+
+    auto c = concore::computation::from_task(std::move(t));
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_void_receiver{&called});
+    REQUIRE(called);
+}
+
+TEST_CASE("just_task with a task returning an error will call set_error", "[computation]") {
+    concore::task t{[] { throw std::logic_error("error"); }};
+
+    auto c = concore::computation::from_task(std::move(t));
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_error_receiver{&called});
+    REQUIRE(called);
+}
+
+TEST_CASE("just_task with a task on a cancelled group will call set_done", "[computation]") {
+    auto grp = concore::task_group::create();
+    grp.cancel();
+    concore::task t{[] {}, std::move(grp)};
+
+    auto c = concore::computation::from_task(std::move(t));
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_done_receiver{&called});
+    REQUIRE(called);
+}
+
+TEST_CASE("just_task on a task with continuation will ensure the task continuation is called "
+          "before the receiver",
+        "[computation]") {
+    std::atomic<int> counter{0};
+    auto f = [&counter] { REQUIRE(counter++ == 0); };
+    auto cont = [&counter](std::exception_ptr ex) {
+        REQUIRE(!ex);
+        REQUIRE(counter++ == 1);
+    };
+    auto recv_fun = [&counter] { REQUIRE(counter++ == 2); };
+
+    concore::task t{std::move(f), {}, std::move(cont)};
+
+    auto c = concore::computation::from_task(std::move(t));
+    ensure_computation<decltype(c), void>();
+
+    auto recv = concore::as_receiver<decltype(recv_fun)>(std::move(recv_fun));
+    concore::computation::run_with(c, recv);
+    REQUIRE(counter.load() == 3);
+}
+
+TEST_CASE("just_task can run with inline_executor", "[computation]") {
+    bool executed{false};
+    auto f = [&executed] { executed = true; };
+    concore::task t{std::move(f)};
+
+    auto c = concore::computation::from_task(std::move(t), concore::inline_executor{});
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_void_receiver{&called});
+    REQUIRE(called);
+    REQUIRE(executed);
+}
+
+TEST_CASE("just_task can run with thread_pool executor", "[computation]") {
+    concore::static_thread_pool pool{1};
+    auto ex = pool.executor();
+
+    bool executed{false};
+    auto f = [&executed, &ex] {
+        REQUIRE(ex.running_in_this_thread());
+        executed = true;
+    };
+    concore::task t{std::move(f)};
+
+    auto c = concore::computation::from_task(std::move(t), ex);
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_void_receiver{&called});
+    pool.wait();
+    REQUIRE(called);
+    REQUIRE(executed);
+}
+
+TEST_CASE("just_task can run with a stopped thread_pool executor, calling set_done()",
+        "[computation]") {
+    concore::static_thread_pool pool{1};
+    auto ex = pool.executor();
+    pool.stop();
+
+    bool executed{false};
+    auto f = [&executed] { executed = true; };
+    concore::task t{std::move(f)};
+
+    auto c = concore::computation::from_task(std::move(t), ex);
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_done_receiver{&called});
+    pool.wait();
+    REQUIRE(called);
+    REQUIRE_FALSE(executed);
+}
+
+TEST_CASE("just_task can run with a throwing executor, calling set_done()", "[computation]") {
+    bool executed{false};
+    auto f = [&executed] { executed = true; };
+    concore::task t{std::move(f)};
+
+    auto c = concore::computation::from_task(std::move(t), throwing_executor{});
+    ensure_computation<decltype(c), void>();
+
+    bool called{false};
+    concore::computation::run_with(c, test_error_receiver{&called});
+    REQUIRE(called);
+    REQUIRE_FALSE(executed);
 }

--- a/test/func/computation/test_computation_algos.cpp
+++ b/test/func/computation/test_computation_algos.cpp
@@ -827,3 +827,31 @@ TEST_CASE("run_on will forward executor exception", "[computation]") {
     }
     CHECK_FALSE(ftor_called);
 }
+
+TEST_CASE("transform can be piped", "[computation]") {
+    auto c = just_value(10) | transform([](int x) { return x * x; });
+    int res = wait(c);
+    CHECK(res == 100);
+}
+
+TEST_CASE("bind can be piped", "[computation]") {
+    auto c = just_value(10) | bind([](int x) { return just_value(x * x); });
+    int res = wait(c);
+    CHECK(res == 100);
+}
+
+TEST_CASE("bind_error can be piped", "[computation]") {
+    auto f = [] {
+        throw std::logic_error("err");
+        return 3;
+    };
+    auto c = from_function(f) | bind_error([](std::exception_ptr) { return just_value(12); });
+    int res = wait(c);
+    CHECK(res == 12);
+}
+
+TEST_CASE("on can be piped", "[computation]") {
+    auto c = just_value(10) | on(concore::spawn_executor{});
+    int res = wait(c);
+    CHECK(res == 10);
+}


### PR DESCRIPTION
- similar to senders/receivers, a "computation" can encode a general computation
- it's much simpler that the senders/receivers framework
- the computation can be a chain of different operations, possible with different threads