### PR TITLE
Update recipe for Conan 2.0 compat. Update packages. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ src/include/concore/version.hpp
 docs/_build
 docs/doxygen_out
 docs/api/
+
+# CMake user presets
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,6 @@ cmake_minimum_required(VERSION 3.17.0)
 # Define the concore project
 project(concore-dev LANGUAGES CXX)
 
-if(EXISTS ${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
-    conan_basic_setup(TARGETS)
-else()
-    message(ERROR "The file conanbuildinfo.cmake doesn't exist, you have to run conan install first")
-endif()
-
 # Set the version of the project
 project(concore-dev VERSION "${CONAN_PACKAGE_VERSION}")
 
@@ -24,6 +17,10 @@ add_subdirectory(src)
 
 # Prevent linking errors with CXX11 or older ABI (visible when linking with rapidcheck)
 target_compile_definitions(concore PUBLIC _GLIBCXX_USE_CXX11_ABI=1)
+
+find_package(Catch2 REQUIRED)
+find_package(rapidcheck REQUIRED)
+find_package(benchmark REQUIRED)
 
 # Testing code
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # concore
+
 Core abstractions for dealing with concurrency in C++
 
 [![CI](https://github.com/lucteo/concore/workflows/CI/badge.svg)](https://github.com/lucteo/concore/actions)
@@ -16,20 +17,35 @@ The library also aims at building highly efficient applications, by trying to ma
 ## Building
 
 The following tools are needed:
-* [`conan`](https://www.conan.io/)
-* [`CMake`](https://cmake.org/)
+
+* [`Conan`](https://www.conan.io/) (>=3.23)
+* [`CMake`](https://cmake.org/) (>=2.0)
 
 Perform the following actions:
-```
+
+```sh
 mkdir -p build
 pushd build
-
-conan install .. --build=missing -s build_type=Release
-
-cmake -G<gen> -D CMAKE_BUILD_TYPE=Release -D concore.testing=ON ..
-cmake --build .
-
-popd build
+conan install .. --build=missing -s build_type=Release -c tools.build:skip_test=False
+cmake --preset conan-release ..
+cmake --build Release
+popd
+ctest --preset conan-release
 ```
 
-Here, `<gen>` can be `Ninja`, `make`, `XCode`, `"Visual Studio 15 Win64"`, etc.
+Or, to build without tests:
+
+```sh
+mkdir -p build
+pushd build
+conan install .. --build=missing -s build_type=Release
+cmake --preset conan-release ../src
+cmake --build Release
+popd
+```
+
+Also, creating the `concore` Conan package and storing it in the local cache can be done in a single shot. To do so, issue the following command from the root of the repository:
+
+```sh
+conan create . --build=missing -s build_type=Release
+```

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,6 +1,10 @@
-from conans import ConanFile, CMake, tools
-import re
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout, CMakeDeps, CMakeToolchain
+from conan.tools.files import copy, load, collect_libs
+from conan.tools.microsoft.visual import is_msvc
 from os import path
+from re import search
+
 
 class ConcoreRecipe(ConanFile):
    name = "concore"
@@ -12,53 +16,73 @@ class ConcoreRecipe(ConanFile):
    license = "MIT"
 
    settings = "os", "compiler", "build_type", "arch"
-   generators = "cmake"
    build_policy = "missing"   # Some of the dependencies don't have builds for all our targets
 
-   options = {"shared": [True, False], "fPIC": [True, False]}
-   default_options = {"shared": False, "fPIC": True, "catch2:with_main": True}
+   options = {"shared": [True, False], "fPIC": [True, False], "no_tbb": [True, False]}
+   default_options = {"shared": False, "fPIC": True, "no_tbb": False, "catch2/*:with_main": True}
 
    exports = "LICENSE"
-   exports_sources = ("src/*", "include/*", "CMakeLists.txt")
+   exports_sources = ("src/*", "test/*", "CMakeLists.txt", "LICENSE")
 
    def set_version(self):
       # Get the version from src/CMakeList.txt project definition
-      content = tools.load(path.join(self.recipe_folder, "src/CMakeLists.txt"))
-      version = re.search(r"project\([^\)]+VERSION (\d+\.\d+\.\d+)[^\)]*\)", content).group(1)
+      content = load(self, path.join(self.recipe_folder, "src", "CMakeLists.txt"))
+      version = search(r"project\([^\)]+VERSION (\d+\.\d+\.\d+)[^\)]*\)", content).group(1)
       self.version = version.strip()
 
    @property
    def _run_tests(self):
-       return tools.get_env("CONAN_RUN_TESTS", False)
+      return not self.conf.get("tools.build:skip_test", default=True)
+   
+   @property
+   def _src_folder(self):
+      return "." if self._run_tests else "src"
 
    def build_requirements(self):
+      if not self.options.no_tbb:
+         self.test_requires("onetbb/[>=2021.10.0]")
+
       if self._run_tests:
-         self.build_requires("catch2/2.13.6")
-         self.build_requires("rapidcheck/20210107")
-         self.build_requires("benchmark/1.5.3")
+         self.test_requires("catch2/2.13.7")
+         self.test_requires("rapidcheck/cci.20210107")
+         self.test_requires("benchmark/1.5.6")
 
    def config_options(self):
-       if self.settings.os == "Windows":
-           del self.options.fPIC
+      if self.settings.os == "Windows":
+         del self.options.fPIC
+
+   def layout(self):
+      cmake_layout(self, src_folder = self._src_folder)
+
+   def generate(self):
+      tc = CMakeToolchain(self)
+      tc.variables["concore.no_tbb"] = self.options.no_tbb
+      if self.settings.os == "Windows" and is_msvc(self) and self.options.shared:
+         tc.variables["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
+      tc.generate()
+
+      deps = CMakeDeps(self)
+      deps.generate()
 
    def build(self):
       # Note: options "shared" and "fPIC" are automatically handled in CMake
       cmake = self._configure_cmake()
       cmake.build()
+      if self._run_tests:
+         cmake.test()
 
    def package(self):
-      self.copy(pattern="LICENSE", dst="licenses")
+      copy(self, "LICENSE", src=self.source_folder, dst=path.join(self.package_folder, "licenses"))
       cmake = self._configure_cmake()
       cmake.install()
 
    def package_info(self):
-      self.cpp_info.libs = self.collect_libs()
+      self.cpp_info.libs = collect_libs(self)
+
+   def package_id(self):
+      del self.info.options.no_tbb
 
    def _configure_cmake(self):
       cmake = CMake(self)
-      if self.settings.compiler == "Visual Studio" and self.options.shared:
-         cmake.definitions["CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS"] = True
-      cmake.configure(source_folder=None if self._run_tests else "src")
+      cmake.configure()
       return cmake
-
-

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class ConcoreRecipe(ConanFile):
 
    def build_requirements(self):
       if not self.options.no_tbb:
-         self.test_requires("onetbb/[>=2021.10.0]")
+         self.test_requires("onetbb/2021.10.0")
 
       if self._run_tests:
          self.test_requires("catch2/2.13.7")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -49,8 +49,8 @@ target_link_libraries(test.concore concore)
 target_include_directories(test.concore PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
 
 # The tests depend on catch2, rapidcheck
-target_link_libraries(test.concore CONAN_PKG::catch2)
-target_link_libraries(test.concore CONAN_PKG::rapidcheck)
+target_link_libraries(test.concore Catch2::Catch2)
+target_link_libraries(test.concore rapidcheck::rapidcheck)
 
 # Check if TBB was enabled
 get_target_property(CONCORE_DEFINES concore COMPILE_DEFINITIONS)
@@ -106,7 +106,7 @@ endif()
 
 function(def_perf_test target sourceFile)
     add_executable(${target} ${sourceFile})
-    target_link_libraries(${target} concore CONAN_PKG::benchmark)
+    target_link_libraries(${target} concore benchmark::benchmark)
     target_compile_definitions(${target} PUBLIC ${EXTRA_DEFS})
     target_include_directories(${target} PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
     if(tbb_link_target)

--- a/test/func/std/test_concept_wrappers.cpp
+++ b/test/func/std/test_concept_wrappers.cpp
@@ -241,6 +241,6 @@ TEST_CASE("as_scheduler produces a good scheduler", "[execution][concept_wrapper
     auto sched = as_scheduler<my_executor>(my_executor{});
     CHECK_FALSE(called);
     concore::submit(sched.schedule(), recv);
-    static_assert(concore::scheduler<typeof(sched)>, "Type is not a scheduler");
+    static_assert(concore::scheduler<decltype(sched)>, "Type is not a scheduler");
     CHECK(called);
 }

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -7,7 +7,7 @@ conan_basic_setup(TARGETS)
 # Test conan package
 add_executable(concore_test_conan test_package.cpp)
 target_compile_features(concore_test_conan PUBLIC cxx_std_17)
-target_link_libraries(concore_test_conan CONAN_PKG::concore)
+target_link_libraries(concore_test_conan concore::concore)
 
 # Test cmake target
 find_package(concore CONFIG REQUIRED)


### PR DESCRIPTION
This PR updates the Conan recipe and CMake script to conform to Conan 2 &mdash; cf. [Conan migration guide to 2.0][migration-guide].

It also fixes a build issue when compiling without GNU extensions.

I'm sorry this PR seems a bit random and without purpose. I was playing with `concore` a while ago and then changed jobs and I completely forgot about it. As I was browsing my repos the other day I noticed those changes here may be handy for someone willing to package it or tweak dependency versions, build systems, etc.

[migration-guide]: https://docs.conan.io/1/conan_v2.html#conan-migration-guide-to-2-0